### PR TITLE
Capture a new frame at cam.capture() call, avoid buffered frames

### DIFF
--- a/capture.c
+++ b/capture.c
@@ -25,12 +25,12 @@ static void log_stderr(camera_log_t type, const char* msg, void* pointer) {
   }
 }
 
-static bool error(camera_t* camera, const char * msg)
+static bool error(const camera_t* camera, const char * msg)
 {
   camera->context.log(CAMERA_ERROR, msg, camera->context.pointer);
   return false;
 }
-static bool failure(camera_t* camera, const char * msg)
+static bool failure(const camera_t* camera, const char * msg)
 {
   camera->context.log(CAMERA_FAIL, msg, camera->context.pointer);
   return false;


### PR DESCRIPTION
This change fix a bug about frame grabbing. With the original code, calling cam.start() starts filling the 4 buffers internally. Suppose you want to grab a frame after some event, ex. by calling cam.capture(...) in 5 seconds, cam.frameRaw() won't contain the frame at the time of cam.capture() call but at cam.start() call. Because of the 4 buffers, you need to call cam.capture() 4 times before starting to get recent frames. In your examples, the workaround you provide is to call cam.capture() continuously so the buffers is constantly renewed.

To make it work, it seems that you need to provide at least 1 buffer to the driver so it could fill it. In the Capture function, I discard the buffer and I wait for the driver to grab a frame at the moment of the capture call. Also, this is why I reduced the internal buffers from 4 to 1.